### PR TITLE
pyupgrade @ 3.7

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -93,8 +93,8 @@ htmlhelp_basename = "%sdoc" % about["__title__"]
 latex_documents = [
     (
         "index",
-        "{0}.tex".format(about["__package_name__"]),
-        "{0} Documentation".format(about["__title__"]),
+        "{}.tex".format(about["__package_name__"]),
+        "{} Documentation".format(about["__title__"]),
         about["__author__"],
         "manual",
     )
@@ -104,7 +104,7 @@ man_pages = [
     (
         "index",
         about["__package_name__"],
-        "{0} Documentation".format(about["__title__"]),
+        "{} Documentation".format(about["__title__"]),
         about["__author__"],
         1,
     )
@@ -113,8 +113,8 @@ man_pages = [
 texinfo_documents = [
     (
         "index",
-        "{0}".format(about["__package_name__"]),
-        "{0} Documentation".format(about["__title__"]),
+        "{}".format(about["__package_name__"]),
+        "{} Documentation".format(about["__title__"]),
         about["__author__"],
         about["__package_name__"],
         about["__description__"],
@@ -187,14 +187,14 @@ def linkcode_resolve(domain, info):  # NOQA: C901
     fn = relpath(fn, start=dirname(cihai_cli.__file__))
 
     if "dev" in about["__version__"]:
-        return "%s/blob/master/%s/%s%s" % (
+        return "{}/blob/master/{}/{}{}".format(
             about["__github__"],
             about["__package_name__"],
             fn,
             linespec,
         )
     else:
-        return "%s/blob/v%s/%s/%s%s" % (
+        return "{}/blob/v{}/{}/{}{}".format(
             about["__github__"],
             about["__version__"],
             about["__package_name__"],

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -19,7 +19,7 @@ def test_cli(test_config_file):
 
 def test_cli_reflects_after_bootstrap(tmpdir, tmpdb_file, unihan_options):
     config = {
-        "database": {"url": "sqlite:///{tmpdb_file}s".format(tmpdb_file=tmpdb_file)},
+        "database": {"url": f"sqlite:///{tmpdb_file}s"},
         "unihan_options": unihan_options,
     }
     config_file = tmpdir.join("config.yml")


### PR DESCRIPTION
```
pip install pyupgrade autoflake; \
pyupgrade --py37 tests/**/*.py docs/**/*.py cihai_cli/**/*.py; \
poetry run autoflake tests/**/*.py docs/**/*.py cihai_cli/**/*.py -i --ignore-init-module-imports --exclude cihai_cli/_compat.py; \
make black isort
```

https://github.com/cihai/cihai/pull/321