### PR TITLE
Remove python 2 compatible module / imports

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -21,6 +21,11 @@ You can test the unpublished version of cihai-cli before its released, see
 
 - _Insert changes/features/fixes for next release here_
 
+### Breaking changes
+
+- Python 2 compatibility module and imports removed. Python 2.x was officially
+  dropped in 0.7.0 (2021-06-15) via #278
+
 ## cihai-cli 0.9.0 (2022-08-16)
 
 ### Compatibility

--- a/cihai_cli/__about__.py
+++ b/cihai_cli/__about__.py
@@ -1,6 +1,6 @@
 __title__ = "cihai-cli"
 __package_name__ = "cihai_cli"
-__version__ = "0.9.0"
+__version__ = "0.10.0a0"
 __description__ = "Command line frontend for the cihai CJK language library"
 __author__ = "Tony Narlock"
 __email__ = "tony@git-pull.com"

--- a/cihai_cli/cli.py
+++ b/cihai_cli/cli.py
@@ -5,7 +5,6 @@ import click
 import yaml
 
 import cihai
-from cihai._compat import PY2
 from cihai.core import Cihai
 from unihan_etl.__about__ import __version__ as __unihan_etl_version__
 
@@ -73,11 +72,7 @@ def cli(ctx, config, log_level):
     ctx.obj["c"] = c  # pass Cihai object down to other commands
 
 
-INFO_SHORT_HELP = (
-    "Get details on a CJK character"
-    if PY2
-    else 'Get details on a CJK character, e.g. "好"'
-)
+INFO_SHORT_HELP = 'Get details on a CJK character, e.g. "好"'
 
 
 @cli.command(name="info", short_help=INFO_SHORT_HELP)
@@ -96,8 +91,6 @@ def command_info(ctx, char, show_all):
     for c in query.__table__.columns._data.keys():
         value = getattr(query, c)
         if value:
-            if PY2:
-                value = value.encode("utf-8")
             if not show_all and str(c) not in HUMAN_UNIHAN_FIELDS:
                 continue
             attrs[str(c)] = value
@@ -125,8 +118,6 @@ def command_reverse(ctx, char, show_all):
         for c in k.__table__.columns._data.keys():
             value = getattr(k, c)
             if value:
-                if PY2:
-                    value = value.encode("utf-8")
                 if not show_all and str(c) not in HUMAN_UNIHAN_FIELDS:
                     continue
                 attrs[str(c)] = value

--- a/poetry.lock
+++ b/poetry.lock
@@ -31,10 +31,10 @@ optional = false
 python-versions = ">=3.5"
 
 [package.extras]
-dev = ["coverage[toml] (>=5.0.2)", "hypothesis", "pympler", "pytest (>=4.3.0)", "mypy (>=0.900,!=0.940)", "pytest-mypy-plugins", "zope.interface", "furo", "sphinx", "sphinx-notfound-page", "pre-commit", "cloudpickle"]
-docs = ["furo", "sphinx", "zope.interface", "sphinx-notfound-page"]
-tests = ["coverage[toml] (>=5.0.2)", "hypothesis", "pympler", "pytest (>=4.3.0)", "mypy (>=0.900,!=0.940)", "pytest-mypy-plugins", "zope.interface", "cloudpickle"]
-tests_no_zope = ["coverage[toml] (>=5.0.2)", "hypothesis", "pympler", "pytest (>=4.3.0)", "mypy (>=0.900,!=0.940)", "pytest-mypy-plugins", "cloudpickle"]
+tests_no_zope = ["cloudpickle", "pytest-mypy-plugins", "mypy (>=0.900,!=0.940)", "pytest (>=4.3.0)", "pympler", "hypothesis", "coverage[toml] (>=5.0.2)"]
+tests = ["cloudpickle", "zope.interface", "pytest-mypy-plugins", "mypy (>=0.900,!=0.940)", "pytest (>=4.3.0)", "pympler", "hypothesis", "coverage[toml] (>=5.0.2)"]
+docs = ["sphinx-notfound-page", "zope.interface", "sphinx", "furo"]
+dev = ["cloudpickle", "pre-commit", "sphinx-notfound-page", "sphinx", "furo", "zope.interface", "pytest-mypy-plugins", "mypy (>=0.900,!=0.940)", "pytest (>=4.3.0)", "pympler", "hypothesis", "coverage[toml] (>=5.0.2)"]
 
 [[package]]
 name = "babel"
@@ -59,8 +59,8 @@ python-versions = ">=3.6.0"
 soupsieve = ">1.2"
 
 [package.extras]
-html5lib = ["html5lib"]
 lxml = ["lxml"]
+html5lib = ["html5lib"]
 
 [[package]]
 name = "black"
@@ -80,10 +80,10 @@ typed-ast = {version = ">=1.4.2", markers = "python_version < \"3.8\" and implem
 typing-extensions = {version = ">=3.10.0.0", markers = "python_version < \"3.10\""}
 
 [package.extras]
-colorama = ["colorama (>=0.4.3)"]
-d = ["aiohttp (>=3.7.4)"]
-jupyter = ["ipython (>=7.8.0)", "tokenize-rt (>=3.2.0)"]
 uvloop = ["uvloop (>=0.15.2)"]
+jupyter = ["tokenize-rt (>=3.2.0)", "ipython (>=7.8.0)"]
+d = ["aiohttp (>=3.7.4)"]
+colorama = ["colorama (>=0.4.3)"]
 
 [[package]]
 name = "certifi"
@@ -232,9 +232,9 @@ typing-extensions = {version = ">=3.6.4", markers = "python_version < \"3.8\""}
 zipp = ">=0.5"
 
 [package.extras]
-docs = ["sphinx", "jaraco.packaging (>=9)", "rst.linker (>=1.9)"]
+testing = ["importlib-resources (>=1.3)", "pytest-mypy (>=0.9.1)", "pytest-black (>=0.3.7)", "pytest-perf (>=0.9.2)", "flufl.flake8", "pyfakefs", "packaging", "pytest-enabler (>=1.3)", "pytest-cov", "pytest-flake8", "pytest-checkdocs (>=2.4)", "pytest (>=6)"]
 perf = ["ipython"]
-testing = ["pytest (>=6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "pytest-cov", "pytest-enabler (>=1.3)", "packaging", "pyfakefs", "flufl.flake8", "pytest-perf (>=0.9.2)", "pytest-black (>=0.3.7)", "pytest-mypy (>=0.9.1)", "importlib-resources (>=1.3)"]
+docs = ["rst.linker (>=1.9)", "jaraco.packaging (>=9)", "sphinx"]
 
 [[package]]
 name = "iniconfig"
@@ -253,10 +253,10 @@ optional = false
 python-versions = ">=3.6.1,<4.0"
 
 [package.extras]
-pipfile_deprecated_finder = ["pipreqs", "requirementslib"]
-requirements_deprecated_finder = ["pipreqs", "pip-api"]
-colors = ["colorama (>=0.4.3,<0.5.0)"]
 plugins = ["setuptools"]
+colors = ["colorama (>=0.4.3,<0.5.0)"]
+requirements_deprecated_finder = ["pip-api", "pipreqs"]
+pipfile_deprecated_finder = ["requirementslib", "pipreqs"]
 
 [[package]]
 name = "jinja2"
@@ -372,9 +372,9 @@ typed-ast = {version = ">=1.4.0,<2", markers = "python_version < \"3.8\""}
 typing-extensions = ">=3.10"
 
 [package.extras]
-dmypy = ["psutil (>=4.0)"]
-python2 = ["typed-ast (>=1.4.0,<2)"]
 reports = ["lxml"]
+python2 = ["typed-ast (>=1.4.0,<2)"]
+dmypy = ["psutil (>=4.0)"]
 
 [[package]]
 name = "mypy-extensions"
@@ -402,10 +402,10 @@ sphinx = ">=4,<6"
 typing-extensions = "*"
 
 [package.extras]
-code_style = ["pre-commit (>=2.12,<3.0)"]
+testing = ["sphinx-pytest", "pytest-param-files (>=0.3.4,<0.4.0)", "pytest-regressions", "pytest-cov", "pytest (>=6,<7)", "coverage", "beautifulsoup4"]
+rtd = ["sphinxext-opengraph (>=0.6.3,<0.7.0)", "sphinxcontrib.mermaid (>=0.7.1,<0.8.0)", "sphinxext-rediraffe (>=0.2.7,<0.3.0)", "sphinx-design", "sphinx-book-theme", "ipython"]
 linkify = ["linkify-it-py (>=1.0,<2.0)"]
-rtd = ["ipython", "sphinx-book-theme", "sphinx-design", "sphinxext-rediraffe (>=0.2.7,<0.3.0)", "sphinxcontrib.mermaid (>=0.7.1,<0.8.0)", "sphinxext-opengraph (>=0.6.3,<0.7.0)"]
-testing = ["beautifulsoup4", "coverage", "pytest (>=6,<7)", "pytest-cov", "pytest-regressions", "pytest-param-files (>=0.3.4,<0.4.0)", "sphinx-pytest"]
+code_style = ["pre-commit (>=2.12,<3.0)"]
 
 [[package]]
 name = "packaging"
@@ -435,8 +435,8 @@ optional = false
 python-versions = ">=3.7"
 
 [package.extras]
-docs = ["furo (>=2021.7.5b38)", "proselint (>=0.10.2)", "sphinx-autodoc-typehints (>=1.12)", "sphinx (>=4)"]
-test = ["appdirs (==1.4.4)", "pytest-cov (>=2.7)", "pytest-mock (>=3.6)", "pytest (>=6)"]
+test = ["pytest (>=6)", "pytest-mock (>=3.6)", "pytest-cov (>=2.7)", "appdirs (==1.4.4)"]
+docs = ["sphinx (>=4)", "sphinx-autodoc-typehints (>=1.12)", "proselint (>=0.10.2)", "furo (>=2021.7.5b38)"]
 
 [[package]]
 name = "pluggy"
@@ -497,7 +497,7 @@ optional = false
 python-versions = ">=3.6.8"
 
 [package.extras]
-diagrams = ["railroad-diagrams", "jinja2"]
+diagrams = ["jinja2", "railroad-diagrams"]
 
 [[package]]
 name = "pytest"
@@ -519,7 +519,7 @@ py = ">=1.8.2"
 tomli = ">=1.0.0"
 
 [package.extras]
-testing = ["argcomplete", "hypothesis (>=3.56)", "mock", "nose", "pygments (>=2.7.2)", "requests", "xmlschema"]
+testing = ["xmlschema", "requests", "pygments (>=2.7.2)", "nose", "mock", "hypothesis (>=3.56)", "argcomplete"]
 
 [[package]]
 name = "pytest-cov"
@@ -589,8 +589,8 @@ idna = ">=2.5,<4"
 urllib3 = ">=1.21.1,<1.27"
 
 [package.extras]
-socks = ["PySocks (>=1.5.6,!=1.5.7)"]
 use_chardet_on_py3 = ["chardet (>=3.0.2,<6)"]
+socks = ["PySocks (>=1.5.6,!=1.5.7)"]
 
 [[package]]
 name = "six"
@@ -644,9 +644,9 @@ sphinxcontrib-qthelp = "*"
 sphinxcontrib-serializinghtml = ">=1.1.5"
 
 [package.extras]
+test = ["typed-ast", "cython", "html5lib", "pytest (>=4.6)"]
+lint = ["types-requests", "types-typed-ast", "docutils-stubs", "sphinx-lint", "mypy (>=0.971)", "isort", "flake8-bugbear", "flake8-comprehensions", "flake8 (>=3.5.0)"]
 docs = ["sphinxcontrib-websupport"]
-lint = ["flake8 (>=3.5.0)", "flake8-comprehensions", "flake8-bugbear", "isort", "mypy (>=0.971)", "sphinx-lint", "docutils-stubs", "types-typed-ast", "types-requests"]
-test = ["pytest (>=4.6)", "html5lib", "cython", "typed-ast"]
 
 [[package]]
 name = "sphinx-autobuild"
@@ -662,7 +662,7 @@ livereload = "*"
 sphinx = "*"
 
 [package.extras]
-test = ["pytest", "pytest-cov"]
+test = ["pytest-cov", "pytest"]
 
 [[package]]
 name = "sphinx-autodoc-typehints"
@@ -691,7 +691,7 @@ python-versions = ">=3.7"
 sphinx = ">=4.0,<6.0"
 
 [package.extras]
-docs = ["furo", "myst-parser", "sphinx-copybutton", "sphinx-inline-tabs", "ipython"]
+docs = ["ipython", "sphinx-inline-tabs", "sphinx-copybutton", "myst-parser", "furo"]
 
 [[package]]
 name = "sphinx-click"
@@ -733,8 +733,8 @@ python-versions = ">=3.6"
 sphinx = ">=3"
 
 [package.extras]
-doc = ["myst-parser", "furo"]
-test = ["pytest", "pytest-cov", "pytest-xdist"]
+test = ["pytest-xdist", "pytest-cov", "pytest"]
+doc = ["furo", "myst-parser"]
 
 [[package]]
 name = "sphinx-issues"
@@ -748,9 +748,9 @@ python-versions = ">=3.6"
 sphinx = "*"
 
 [package.extras]
-dev = ["pytest (>=6.2.0)", "flake8 (==3.9.2)", "flake8-bugbear (==20.11.1)", "pre-commit (>=2.7,<3.0)", "tox"]
-lint = ["flake8 (==3.9.2)", "flake8-bugbear (==20.11.1)", "pre-commit (>=2.7,<3.0)"]
 tests = ["pytest (>=6.2.0)"]
+lint = ["pre-commit (>=2.7,<3.0)", "flake8-bugbear (==20.11.1)", "flake8 (==3.9.2)"]
+dev = ["tox", "pre-commit (>=2.7,<3.0)", "flake8-bugbear (==20.11.1)", "flake8 (==3.9.2)", "pytest (>=6.2.0)"]
 
 [[package]]
 name = "sphinxcontrib-applehelp"
@@ -820,8 +820,8 @@ optional = false
 python-versions = ">=3.5"
 
 [package.extras]
-lint = ["flake8", "mypy", "docutils-stubs"]
 test = ["pytest"]
+lint = ["docutils-stubs", "mypy", "flake8"]
 
 [[package]]
 name = "sphinxext-opengraph"
@@ -935,9 +935,9 @@ optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, !=3.5.*, <4"
 
 [package.extras]
-brotli = ["brotlicffi (>=0.8.0)", "brotli (>=1.0.9)", "brotlipy (>=0.6.0)"]
-secure = ["pyOpenSSL (>=0.14)", "cryptography (>=1.3.4)", "idna (>=2.0.0)", "certifi", "ipaddress"]
 socks = ["PySocks (>=1.5.6,!=1.5.7,<2.0)"]
+secure = ["ipaddress", "certifi", "idna (>=2.0.0)", "cryptography (>=1.3.4)", "pyOpenSSL (>=0.14)"]
+brotli = ["brotlipy (>=0.6.0)", "brotli (>=1.0.9)", "brotlicffi (>=0.8.0)"]
 
 [[package]]
 name = "watchdog"
@@ -967,8 +967,8 @@ optional = false
 python-versions = ">=3.7"
 
 [package.extras]
-docs = ["sphinx", "jaraco.packaging (>=9)", "rst.linker (>=1.9)", "jaraco.tidelift (>=1.4)"]
-testing = ["pytest (>=6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "pytest-cov", "pytest-enabler (>=1.3)", "jaraco.itertools", "func-timeout", "pytest-black (>=0.3.7)", "pytest-mypy (>=0.9.1)"]
+testing = ["pytest-mypy (>=0.9.1)", "pytest-black (>=0.3.7)", "func-timeout", "jaraco.itertools", "pytest-enabler (>=1.3)", "pytest-cov", "pytest-flake8", "pytest-checkdocs (>=2.4)", "pytest (>=6)"]
+docs = ["jaraco.tidelift (>=1.4)", "rst.linker (>=1.9)", "jaraco.packaging (>=9)", "sphinx"]
 
 [extras]
 coverage = []
@@ -980,7 +980,7 @@ test = []
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.7"
-content-hash = "b29b7601e0b6b5c2e26dd0522fff03fdae3a2fd70df70e9c3aff53e8e3cfb172"
+content-hash = "a32da46b924e92cdd69c38ed43870dfc0eddf75cb33847b59315b6dcf3190219"
 
 [metadata.files]
 alabaster = [

--- a/poetry.lock
+++ b/poetry.lock
@@ -106,7 +106,7 @@ unicode_backport = ["unicodedata2"]
 
 [[package]]
 name = "cihai"
-version = "0.13.0"
+version = "0.14.0"
 description = "Library for CJK (chinese, japanese, korean) language data."
 category = "main"
 optional = false
@@ -116,10 +116,10 @@ python-versions = ">=3.7,<4.0"
 appdirs = "*"
 kaptan = "*"
 sqlalchemy = "<1.4"
-unihan-etl = ">=0.14.0,<0.15.0"
+unihan-etl = ">=0.15.0,<0.16.0"
 
 [package.extras]
-cli = ["cihai-cli (>=0.9.0,<0.10.0)"]
+cli = ["cihai-cli (>=0.10.0a0,<0.11.0)"]
 
 [[package]]
 name = "click"
@@ -915,7 +915,7 @@ python-versions = "*"
 
 [[package]]
 name = "unihan-etl"
-version = "0.14.0"
+version = "0.15.0"
 description = "Export UNIHAN data of Chinese, Japanese, Korean to CSV, JSON or YAML"
 category = "main"
 optional = false
@@ -1040,8 +1040,8 @@ charset-normalizer = [
     {file = "charset_normalizer-2.1.1-py3-none-any.whl", hash = "sha256:83e9a75d1911279afd89352c68b45348559d1fc0506b054b346651b5e7fee29f"},
 ]
 cihai = [
-    {file = "cihai-0.13.0-py3-none-any.whl", hash = "sha256:27146d653d6411a825d32acebdc6b324023b26aeb7dc12485dee8536609c3ba2"},
-    {file = "cihai-0.13.0.tar.gz", hash = "sha256:7bc79fadf2eb32e9a6f9dbb851b3a25f17fb82e60d0e188adfffd2dcf14e42ec"},
+    {file = "cihai-0.14.0-py3-none-any.whl", hash = "sha256:c5c8b767142a72f22bd2727d0bd6050dae2c7dd8c9ac425fedd674d7f1c00cca"},
+    {file = "cihai-0.14.0.tar.gz", hash = "sha256:a74e38e041bc907960370d1f36c119b1c7a90f9fc7d1b7aace16540d1bdd11dd"},
 ]
 click = [
     {file = "click-8.1.3-py3-none-any.whl", hash = "sha256:bb4d8133cb15a609f44e8213d9b391b0809795062913b383c62be0ee95b1db48"},
@@ -1499,8 +1499,8 @@ unicodecsv = [
     {file = "unicodecsv-0.14.1.tar.gz", hash = "sha256:018c08037d48649a0412063ff4eda26eaa81eff1546dbffa51fa5293276ff7fc"},
 ]
 unihan-etl = [
-    {file = "unihan-etl-0.14.0.tar.gz", hash = "sha256:1e42c42ecce014ed5464d91ec85c0c1ee0203c3ee422f7dd0a9a2b7cf6939ced"},
-    {file = "unihan_etl-0.14.0-py3-none-any.whl", hash = "sha256:2740e1869227c9d97df784de8e6dc993dd20da9415451e3d2ee9d280276f1590"},
+    {file = "unihan-etl-0.15.0.tar.gz", hash = "sha256:12d4b2e937558cb2d156d974caddc51d1ebcae969b626243bc921f0301663611"},
+    {file = "unihan_etl-0.15.0-py3-none-any.whl", hash = "sha256:49897741ec76bf1492c745cebe9980e7e244c850361250895e1ed55d5631efc1"},
 ]
 urllib3 = [
     {file = "urllib3-1.26.11-py2.py3-none-any.whl", hash = "sha256:c33ccba33c819596124764c23a97d25f32b28433ba0dedeb77d873a38722c9bc"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,7 +58,7 @@ Repository = "https://github.com/cihai/cihai-cli"
 [tool.poetry.dependencies]
 python = "^3.7"
 click = ">=7<8.2"
-cihai = ">=0.12.0,<0.14.0"
+cihai = ">=0.12.0,<0.15.0"
 PyYAML = "<6,>=3.12"
 
 [tool.poetry.dev-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "cihai-cli"
-version = "0.9.0"
+version = "0.10.0a0"
 description = "Command line frontend for the cihai CJK language library"
 license = "MIT"
 authors = ["Tony Narlock <tony@git-pull.com>"]


### PR DESCRIPTION
Python 2.x was officially dropped in 0.7.0 (2021-06-15) via #278

This was from [cihai](https://github.com/cihai/cihai/) itself, it means we'll want to be strict about dependencies, 0.14.0+ of cihai [won't have the PY2 import anymore](https://github.com/cihai/cihai/pull/325).

https://github.com/cihai/unihan-etl/pull/258, https://github.com/cihai/unihan-db/pull/299, https://github.com/cihai/cihai/pull/325, **https://github.com/cihai/cihai-cli/pull/278**