### PR TITLE
Package name: `cihai[cli]` -> `cihai-cli`

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -6,13 +6,13 @@ You can test the unpublished version of cihai-cli before its released, see
 - [pip](https://pip.pypa.io/en/stable/):
 
   ```console
-  $ pip install --user --upgrade --pre 'cihai[cli]'
+  $ pip install --user --upgrade --pre cihai-cli
   ```
 
 - [pipx](https://pypa.github.io/pipx/docs/):
 
   ```console
-  $ pipx install --suffix=@next 'cihai[cli]' --pip-args '\--pre' --include-deps --force
+  $ pipx install --suffix=@next cihai-cli --pip-args '\--pre' --include-deps --force
   ```
 
   Then use `cihai@next info 好`.

--- a/CHANGES
+++ b/CHANGES
@@ -17,9 +17,33 @@ You can test the unpublished version of cihai-cli before its released, see
 
   Then use `cihai@next info 好`.
 
-## cihai-cli 0.11.x (unreleased)
+## cihai-cli 0.12.x (unreleased)
 
 - _Insert changes/features/fixes for next release here_
+
+## cihai-cli 0.11.0 (2022-08-20)
+
+### Breaking changes
+
+The CLI version of `cihai` installed through `cihai-cli` again
+
+Before (cihai 0.9 to 0.14, cihai-cli 0.5 to 0.10):
+
+```console
+$ pip install cihai[cli]
+```
+
+After (cihai 0.15+, cihai-cli 0.11+):
+
+```console
+$ pip install cihai-cli
+```
+
+This made deploying cihai + cihai-cli and pinning packages extremely laborious.
+
+We can reinvestigate this model in the future.
+
+via: [cihai#326](https://github.com/cihai/cihai/pull/326), **[cihai-cli#279](https://github.com/cihai/cihai-cli/pull/279)**
 
 ## cihai-cli 0.10.x (2022-08-20)
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ This project is under active development. Follow our progress and check back for
 ## Installation
 
 ```console
-$ pip install --user 'cihai[cli]'
+$ pip install --user 'cihai-cli'
 ```
 
 ### Developmental releases
@@ -18,13 +18,13 @@ You can test the unpublished version of cihai-cli before its released.
 - [pip](https://pip.pypa.io/en/stable/):
 
   ```console
-  $ pip install --user --upgrade --pre 'cihai[cli]'
+  $ pip install --user --upgrade --pre cihai-cli
   ```
 
 - [pipx](https://pypa.github.io/pipx/docs/):
 
   ```console
-  $ pipx install --suffix=@next 'cihai[cli]' --pip-args '\--pre' --include-deps --force
+  $ pipx install --suffix=@next cihai-cli --pip-args '\--pre' --include-deps --force
   ```
 
   Then use `cihai@next info 好`.

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -7,7 +7,7 @@ cihai is designed to work out-of-the-box without configuration.
 ## Installation
 
 ```{code-block} sh
-$ pip install --user cihai[cli]
+$ pip install --user cihai-cli
 ```
 
 ### Developmental releases
@@ -19,13 +19,13 @@ the 4th beta release of `1.10.0` before general availability.
 - [pip]\:
 
   ```console
-  $ pip install --user --upgrade --pre cihai[cli]
+  $ pip install --user --upgrade --pre cihai-cli
   ```
 
 - [pipx]\:
 
   ```console
-  $ pipx install --suffix=@next 'cihai[cli]' --pip-args '\--pre' --include-deps --force
+  $ pipx install --suffix=@next cihai-cli --pip-args '\--pre' --include-deps --force
   ```
 
   Then use `cihai@next info 好`.
@@ -35,13 +35,13 @@ via trunk (can break easily):
 - [pip]\:
 
   ```console
-  $ pip install --user -e git+https://github.com/cihai/cihai-cli.git#egg=cihai[cli]
+  $ pip install --user -e git+https://github.com/cihai/cihai-cli.git#egg=cihai-cli
   ```
 
 - [pipx]\:
 
   ```console
-  $ pipx install --suffix=@master 'cihai[cli] @ git+https://github.com/cihai/cihai.git@master' --include-deps --force
+  $ pipx install --suffix=@master 'cihai-cli @ git+https://github.com/cihai/cihai.git@master' --include-deps --force
   ```
 
 [pip]: https://pip.pypa.io/en/stable/


### PR DESCRIPTION
https://github.com/cihai/cihai/pull/326, **https://github.com/cihai/cihai-cli/pull/279**

The CLI version of `cihai` installed through `cihai-cli` again

Old (cihai 0.9 to 0.14, cihai-cli 0.5 to 0.10):

```console
$ pip install cihai[cli]
```

After (cihai 0.15+, cihai-cli 0.11+):

```console
$ pip install cihai-cli
```

This made deploying cihai + cihai-cli and pinning packages extremely laborious.

We can reinvestigate this model in the future.