### PR TITLE
docs: Move to sphinx-autoissues

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -21,6 +21,10 @@ You can test the unpublished version of cihai-cli before its released, see
 
 - _Insert changes/features/fixes for next release here_
 
+### Documentation
+
+- Render changelog with sphinx-autoissues, #280
+
 ## cihai-cli 0.12.0 (2022-08-21)
 
 ### Internal

--- a/CHANGES
+++ b/CHANGES
@@ -101,7 +101,7 @@ Infrastructure updates for static type checking and doctest examples.
 
 ## cihai-cli 0.8.0 (2021-06-16)
 
-- {issue}`252`: Convert to markdown
+- #252: Convert to markdown
 
 ## cihai-cli 0.7.2 (2021-06-15)
 
@@ -115,19 +115,19 @@ Infrastructure updates for static type checking and doctest examples.
 
 - Update {}`black` to 21.6b0
 - Update trove classifiers to 3.9
-- {issue}`251` Drop python 2.7 and 3.5. Remove deprecated `__future__` and modesets
+- #251 Drop python 2.7 and 3.5. Remove deprecated `__future__` and modesets
 
 ## cihai-cli 0.6.0 (2020-08-09)
 
-- {issue}`249` Move packaging / publishing to poetry
-- {issue}`248` Self host docs
-- {issue}`248` Add metadata / icons / etc. for doc site
-- {issue}`248` Move travis -> github actions
-- {issue}`248` Overhaul Makefiles
+- #249 Move packaging / publishing to poetry
+- #248 Self host docs
+- #248 Add metadata / icons / etc. for doc site
+- #248 Move travis -> github actions
+- #248 Overhaul Makefiles
 
 ## cihai-cli 0.5.1 (2020-07-03)
 
-- {issue}`247` - Move from Pipfile to Poetry
+- #247 - Move from Pipfile to Poetry
 - Fixed bug in Python 2.x when showing help / "cihai"
 
 ## cihai-cli 0.5.0 (2019-08-18)
@@ -140,7 +140,7 @@ Infrastructure updates for static type checking and doctest examples.
 
 ## cihai-cli 0.5.0a (2018-09-08)
 
-- {issue}`91` `-V` / `-version` now shows the cihai backend version.
+- #91 `-V` / `-version` now shows the cihai backend version.
 
 ## cihai-cli 0.4.1 (2018-07-21)
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -29,7 +29,7 @@ extensions = [
     "sphinx.ext.napoleon",
     "sphinx_click.ext",  # sphinx-click
     "sphinx_inline_tabs",
-    "sphinx_issues",
+    "sphinx_autoissues",
     "sphinx_copybutton",
     "sphinxext.opengraph",
     "sphinxext.rediraffe",
@@ -88,6 +88,10 @@ html_sidebars = {
     ]
 }
 
+# sphinx-autoissues
+issuetracker = "github"
+issuetracker_project = "cihai/cihai-cli"
+
 # sphinxext.opengraph
 ogp_site_url = about["__docs__"]
 ogp_image = "_static/img/icons/icon-192x192.png"
@@ -100,9 +104,6 @@ copybutton_prompt_text = (
 )
 copybutton_prompt_is_regexp = True
 copybutton_remove_prompts = True
-
-# sphinx-issues
-issues_github_path = "cihai/cihai-cli"
 
 # sphinxext-rediraffe
 rediraffe_redirects = "redirects.txt"

--- a/poetry.lock
+++ b/poetry.lock
@@ -742,22 +742,6 @@ doc = ["furo", "myst-parser"]
 test = ["pytest", "pytest-cov", "pytest-xdist"]
 
 [[package]]
-name = "sphinx-issues"
-version = "3.0.1"
-description = "A Sphinx extension for linking to your project's issue tracker"
-category = "dev"
-optional = false
-python-versions = ">=3.6"
-
-[package.dependencies]
-sphinx = "*"
-
-[package.extras]
-dev = ["flake8 (==3.9.2)", "flake8-bugbear (==20.11.1)", "pre-commit (>=2.7,<3.0)", "pytest (>=6.2.0)", "tox"]
-lint = ["flake8 (==3.9.2)", "flake8-bugbear (==20.11.1)", "pre-commit (>=2.7,<3.0)"]
-tests = ["pytest (>=6.2.0)"]
-
-[[package]]
 name = "sphinxcontrib-applehelp"
 version = "1.0.2"
 description = "sphinxcontrib-applehelp is a sphinx extension which outputs Apple help books"
@@ -985,7 +969,7 @@ test = []
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.7"
-content-hash = "527c4e0bb5a68135200fef4b821e991403f031cee9a6b77f04585bd39fa7960e"
+content-hash = "74a98f01ef8b6b2437426faf8a7df28883537519017f5a3266a6be5cbd7ae6c1"
 
 [metadata.files]
 alabaster = [
@@ -1380,10 +1364,6 @@ sphinx-copybutton = [
 sphinx-inline-tabs = [
     {file = "sphinx_inline_tabs-2021.4.11b8-py3-none-any.whl", hash = "sha256:efd6e7ad576a6bc1c616cbaa9b0e6f6fe2b28a776947069ed8d6037667799808"},
     {file = "sphinx_inline_tabs-2021.4.11b8.tar.gz", hash = "sha256:3c4d7759cbbb7752b7e7acd96ed0ea2c58fcc4ae38891a718544b931a5a4818f"},
-]
-sphinx-issues = [
-    {file = "sphinx-issues-3.0.1.tar.gz", hash = "sha256:b7c1dc1f4808563c454d11c1112796f8c176cdecfee95f0fd2302ef98e21e3d6"},
-    {file = "sphinx_issues-3.0.1-py3-none-any.whl", hash = "sha256:8b25dc0301159375468f563b3699af7a63720fd84caf81c1442036fcd418b20c"},
 ]
 sphinxcontrib-applehelp = [
     {file = "sphinxcontrib-applehelp-1.0.2.tar.gz", hash = "sha256:a072735ec80e7675e3f432fcae8610ecf509c5f1869d17e2eecff44389cdbc58"},

--- a/poetry.lock
+++ b/poetry.lock
@@ -677,6 +677,14 @@ testing = ["covdefaults (>=2.2)", "coverage (>=6.4.2)", "diff-cover (>=6.5.1)", 
 type_comments = ["typed-ast (>=1.5.4)"]
 
 [[package]]
+name = "sphinx-autoissues"
+version = "0.0.1"
+description = "Sphinx integration with different issuetrackers"
+category = "dev"
+optional = false
+python-versions = ">=3.7,<4.0"
+
+[[package]]
 name = "sphinx-basic-ng"
 version = "0.0.1a12"
 description = "A modern skeleton for Sphinx themes."
@@ -977,7 +985,7 @@ test = []
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.7"
-content-hash = "ff2b0556e0811b7b545ec3fbdb2f266d3b0df57569acb39e2ce99f5a662067ff"
+content-hash = "527c4e0bb5a68135200fef4b821e991403f031cee9a6b77f04585bd39fa7960e"
 
 [metadata.files]
 alabaster = [
@@ -1352,6 +1360,10 @@ sphinx-autobuild = [
 sphinx-autodoc-typehints = [
     {file = "sphinx_autodoc_typehints-1.19.2-py3-none-any.whl", hash = "sha256:3d761de928d5a86901331133d6d4a2552afa2e798ebcfc0886791792aeb4dd9a"},
     {file = "sphinx_autodoc_typehints-1.19.2.tar.gz", hash = "sha256:872fb2d7b3d794826c28e36edf6739e93549491447dcabeb07c58855e9f914de"},
+]
+sphinx-autoissues = [
+    {file = "sphinx-autoissues-0.0.1.tar.gz", hash = "sha256:a308fd914d700ff2aa2b4584c29975a030ede7171898130ec816eca7ec2c8ce8"},
+    {file = "sphinx_autoissues-0.0.1-py3-none-any.whl", hash = "sha256:07503b774c3a64b97d2614fa409410316fbfeb87ba4553dbe3a7d2131b7453a0"},
 ]
 sphinx-basic-ng = [
     {file = "sphinx_basic_ng-0.0.1a12-py3-none-any.whl", hash = "sha256:e8b6efd2c5ece014156de76065eda01ddfca0fee465aa020b1e3c12f84570bbe"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -68,7 +68,6 @@ furo = "*"
 sphinx-autobuild = "*"
 sphinx-autodoc-typehints = "*"
 sphinx-click = "*"
-sphinx-issues = "*"
 sphinx-inline-tabs = { version = "*", python = "^3.7" }
 sphinxext-opengraph = "*"
 sphinx-copybutton = "*"
@@ -103,7 +102,6 @@ cihai = "cihai_cli.cli:cli"
 docs = [
   "docutils",
   "sphinx",
-  "sphinx-issues",
   "sphinx-click",
   "sphinx-autodoc-typehints",
   "sphinx-autobuild",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -73,6 +73,7 @@ sphinx-inline-tabs = { version = "*", python = "^3.7" }
 sphinxext-opengraph = "*"
 sphinx-copybutton = "*"
 sphinxext-rediraffe = "*"
+sphinx-autoissues = "*"
 myst_parser = "*"
 docutils = "~0.18.0"
 
@@ -110,6 +111,7 @@ docs = [
   "sphinxext-opengraph",
   "sphinx-inline-tabs",
   "sphinxext-rediraffe",
+  "sphinx-autoissues",
   "myst_parser",
   "furo",
 ]


### PR DESCRIPTION
https://github.com/tony/sphinx-autoissues ([Homepage](https://sphinx-autoissues.git-pull.com/))

This is a fork of [sphinxcontrib-issuetracker](https://github.com/lunaryorn/sphinxcontrib-issuetracker) but heavily modified. In the end the similarities between the packages may be less: But the major point is we want plain text issues to be linked

unihan-db and unihan-etl already did this directly to master / trunk

See also: https://github.com/cihai/cihai/pull/327