### PR TITLE
docs: Move to `gp-libs` (our internal helpers for sphinx)

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -28,7 +28,14 @@ You can test the unpublished version of cihai-cli before its released, see
 
 ### Documentation
 
-- Render changelog with sphinx-autoissues, #280
+- Render changelog in [`linkify_issues`] (~~#280~~, #283)
+- Fix Table of contents rendering with sphinx autodoc with [`sphinx_toctree_autodoc_fix`] (#283)
+- Test doctests in our docs via [`pytest_doctest_docutils`] (built on [`doctest_docutils`]) (#283)
+
+[`linkify_issues`]: https://gp-libs.git-pull.com/linkify_issues/
+[`sphinx_toctree_autodoc_fix`]: https://gp-libs.git-pull.com/sphinx_toctree_autodoc_fix/
+[`pytest_doctest_docutils`]: https://gp-libs.git-pull.com/doctest/pytest.html
+[`doctest_docutils`]: https://gp-libs.git-pull.com/doctest
 
 ## cihai-cli 0.12.0 (2022-08-21)
 

--- a/cihai_cli/cli.py
+++ b/cihai_cli/cli.py
@@ -82,6 +82,7 @@ INFO_SHORT_HELP = 'Get details on a CJK character, e.g. "好"'
 )
 @click.pass_context
 def command_info(ctx, char, show_all):
+    """Look up a definition by term."""
     c = ctx.obj["c"]
     query = c.unihan.lookup_char(char).first()
     attrs = {}
@@ -108,6 +109,7 @@ def command_info(ctx, char, show_all):
 )
 @click.pass_context
 def command_reverse(ctx, char, show_all):
+    """Lookup a word or phrase by searching definitions."""
     c = ctx.obj["c"]
     query = c.unihan.reverse_char([char])
     if not query.count():

--- a/docs/api.md
+++ b/docs/api.md
@@ -4,21 +4,26 @@
 
 ```
 
-# API
+# Internal API
 
-:::{seealso}
+```{seealso}
 
 {ref}`cihai's API <cihai:api>`
 
-:::
+```
 
 ## Internals
 
-:::{warning} These APIs are purely internal not covered by versioning policies, they can and will
+```{warning}
+These APIs are purely internal not covered by versioning policies, they can and will
 break between versions. If you need an internal API stabilized please
-[file an issue](https://github.com/cihai/cihai-cli/issues). :::
+[file an issue](https://github.com/cihai/cihai-cli/issues).
+```
 
 ```{eval-rst}
 .. automodule:: cihai_cli.cli
    :members:
+   :undoc-members:
+   :special-members:
+   :show-inheritance:
 ```

--- a/docs/cli/info.md
+++ b/docs/cli/info.md
@@ -1,5 +1,3 @@
-(cihai-info)=
-
 ```{eval-rst}
 .. click:: cihai_cli.cli:command_info
     :prog: cihai info

--- a/docs/cli/reverse.md
+++ b/docs/cli/reverse.md
@@ -1,5 +1,3 @@
-(cihai-reverse)=
-
 ```{eval-rst}
 .. click:: cihai_cli.cli:command_reverse
     :prog: cihai reverse

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -92,6 +92,14 @@ html_sidebars = {
 # linkify_issues
 issue_url_tpl = "https://github.com/cihai/cihai-cli/issues/{issue_id}"
 
+# sphinx.ext.autodoc
+autoclass_content = "both"
+autodoc_member_order = "bysource"
+
+# sphinx-autodoc-typehints
+autodoc_typehints = "description"  # show type hints in doc body instead of signature
+simplify_optional_unions = True
+
 # sphinxext.opengraph
 ogp_site_url = about["__docs__"]
 ogp_image = "_static/img/icons/icon-192x192.png"

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -37,7 +37,12 @@ extensions = [
     "linkify_issues",
 ]
 
-myst_enable_extensions = ["colon_fence", "substitution", "replacements"]
+myst_enable_extensions = [
+    "colon_fence",
+    "substitution",
+    "replacements",
+    "strikethrough",
+]
 
 templates_path = ["_templates"]
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -29,11 +29,12 @@ extensions = [
     "sphinx.ext.napoleon",
     "sphinx_click.ext",  # sphinx-click
     "sphinx_inline_tabs",
-    "sphinx_autoissues",
     "sphinx_copybutton",
     "sphinxext.opengraph",
     "sphinxext.rediraffe",
     "myst_parser",
+    "sphinx_toctree_autodoc_fix",
+    "linkify_issues",
 ]
 
 myst_enable_extensions = ["colon_fence", "substitution", "replacements"]
@@ -88,9 +89,8 @@ html_sidebars = {
     ]
 }
 
-# sphinx-autoissues
-issuetracker = "github"
-issuetracker_project = "cihai/cihai-cli"
+# linkify_issues
+issue_url_tpl = "https://github.com/cihai/cihai-cli/issues/{issue_id}"
 
 # sphinxext.opengraph
 ogp_site_url = about["__docs__"]

--- a/docs/index.md
+++ b/docs/index.md
@@ -18,6 +18,7 @@ cli/index
 :caption: Project
 :hidden:
 
+api
 history
 Developer Guide <https://cihai.git-pull.com/contributing/>
 GitHub <https://github.com/cihai/cihai-cli>

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -6,7 +6,7 @@ cihai is designed to work out-of-the-box without configuration.
 
 ## Installation
 
-```{code-block} sh
+```console
 $ pip install --user cihai-cli
 ```
 

--- a/poetry.lock
+++ b/poetry.lock
@@ -707,14 +707,6 @@ testing = ["covdefaults (>=2.2)", "coverage (>=6.4.2)", "diff-cover (>=6.5.1)", 
 type_comments = ["typed-ast (>=1.5.4)"]
 
 [[package]]
-name = "sphinx-autoissues"
-version = "0.0.1"
-description = "Sphinx integration with different issuetrackers"
-category = "dev"
-optional = false
-python-versions = ">=3.7,<4.0"
-
-[[package]]
 name = "sphinx-basic-ng"
 version = "0.0.1a12"
 description = "A modern skeleton for Sphinx themes."
@@ -999,7 +991,7 @@ test = []
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.7"
-content-hash = "f1a11a251d76414f29a994047eb874e511a0d1ea31cac6faf5e6f5ff85c88930"
+content-hash = "6e035ec4d2576d115a6b803d68fd506f35f906f12b4cab52604f2508e982ad23"
 
 [metadata.files]
 alabaster = [
@@ -1353,10 +1345,6 @@ sphinx-autobuild = [
 sphinx-autodoc-typehints = [
     {file = "sphinx_autodoc_typehints-1.19.2-py3-none-any.whl", hash = "sha256:3d761de928d5a86901331133d6d4a2552afa2e798ebcfc0886791792aeb4dd9a"},
     {file = "sphinx_autodoc_typehints-1.19.2.tar.gz", hash = "sha256:872fb2d7b3d794826c28e36edf6739e93549491447dcabeb07c58855e9f914de"},
-]
-sphinx-autoissues = [
-    {file = "sphinx-autoissues-0.0.1.tar.gz", hash = "sha256:a308fd914d700ff2aa2b4584c29975a030ede7171898130ec816eca7ec2c8ce8"},
-    {file = "sphinx_autoissues-0.0.1-py3-none-any.whl", hash = "sha256:07503b774c3a64b97d2614fa409410316fbfeb87ba4553dbe3a7d2131b7453a0"},
 ]
 sphinx-basic-ng = [
     {file = "sphinx_basic_ng-0.0.1a12-py3-none-any.whl", hash = "sha256:e8b6efd2c5ece014156de76065eda01ddfca0fee465aa020b1e3c12f84570bbe"},

--- a/poetry.lock
+++ b/poetry.lock
@@ -220,6 +220,18 @@ sphinx = ">=4.0,<6.0"
 sphinx-basic-ng = "*"
 
 [[package]]
+name = "gp-libs"
+version = "0.0.1a9"
+description = "Internal utilities for projects following git-pull python package spec"
+category = "dev"
+optional = false
+python-versions = ">=3.7,<4.0"
+
+[package.dependencies]
+docutils = ">=0.18.0,<0.19.0"
+myst_parser = "*"
+
+[[package]]
 name = "idna"
 version = "3.3"
 description = "Internationalized Domain Names in Applications (IDNA)"
@@ -987,7 +999,7 @@ test = []
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.7"
-content-hash = "4c4c03e670a1d596342980159d6225691db125114acdb370b98a2347683484ee"
+content-hash = "f1a11a251d76414f29a994047eb874e511a0d1ea31cac6faf5e6f5ff85c88930"
 
 [metadata.files]
 alabaster = [
@@ -1131,6 +1143,10 @@ flake8-comprehensions = [
 furo = [
     {file = "furo-2022.6.21-py3-none-any.whl", hash = "sha256:061b68e323345e27fcba024cf33a1e77f3dfd8d9987410be822749a706e2add6"},
     {file = "furo-2022.6.21.tar.gz", hash = "sha256:9aa983b7488a4601d13113884bfb7254502c8729942e073a0acb87a5512af223"},
+]
+gp-libs = [
+    {file = "gp-libs-0.0.1a9.tar.gz", hash = "sha256:835608ba29220c4d77e7e3f5a9ae27368ac1eb4b43f0cd1e6cdec9c27e9a9e3a"},
+    {file = "gp_libs-0.0.1a9-py3-none-any.whl", hash = "sha256:2c055bd65f0880325a800775a2ee4c23dacc9eb8a56408fdb665a66da7d38ed3"},
 ]
 idna = [
     {file = "idna-3.3-py3-none-any.whl", hash = "sha256:84d9dd047ffa80596e0f246e2eab0b391788b0503584e8945f2368256d2735ff"},

--- a/poetry.lock
+++ b/poetry.lock
@@ -221,7 +221,7 @@ sphinx-basic-ng = "*"
 
 [[package]]
 name = "gp-libs"
-version = "0.0.1a9"
+version = "0.0.1a10"
 description = "Internal utilities for projects following git-pull python package spec"
 category = "dev"
 optional = false
@@ -991,7 +991,7 @@ test = []
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.7"
-content-hash = "6e035ec4d2576d115a6b803d68fd506f35f906f12b4cab52604f2508e982ad23"
+content-hash = "ac9f62098f3a57aff944d2b750cedab4de3bbfbe727223fdb5044f53cdf05673"
 
 [metadata.files]
 alabaster = [
@@ -1137,8 +1137,8 @@ furo = [
     {file = "furo-2022.6.21.tar.gz", hash = "sha256:9aa983b7488a4601d13113884bfb7254502c8729942e073a0acb87a5512af223"},
 ]
 gp-libs = [
-    {file = "gp-libs-0.0.1a9.tar.gz", hash = "sha256:835608ba29220c4d77e7e3f5a9ae27368ac1eb4b43f0cd1e6cdec9c27e9a9e3a"},
-    {file = "gp_libs-0.0.1a9-py3-none-any.whl", hash = "sha256:2c055bd65f0880325a800775a2ee4c23dacc9eb8a56408fdb665a66da7d38ed3"},
+    {file = "gp-libs-0.0.1a10.tar.gz", hash = "sha256:54fbe07f42628b114f0b1472bb03ce75be2928090ec26d8d6f675f3bd9f58c2e"},
+    {file = "gp_libs-0.0.1a10-py3-none-any.whl", hash = "sha256:701b190ffd468ca4d776b196707344748dd550aea03db9aaa1ffdecdd0c32506"},
 ]
 idna = [
     {file = "idna-3.3-py3-none-any.whl", hash = "sha256:84d9dd047ffa80596e0f246e2eab0b391788b0503584e8945f2368256d2735ff"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,6 +64,7 @@ PyYAML = "<6,>=3.12"
 [tool.poetry.dev-dependencies]
 ### Docs ###
 sphinx = "*"
+gp-libs = "*"
 furo = "*"
 sphinx-autobuild = "*"
 sphinx-autodoc-typehints = "*"
@@ -114,11 +115,18 @@ docs = [
   "sphinx-autoissues",
   "myst_parser",
   "furo",
+  "gp-libs",
 ]
 test = ["pytest", "pytest-rerunfailures", "pytest-watcher"]
 coverage = ["codecov", "coverage", "pytest-cov"]
 format = ["black", "isort"]
-lint = ["flake8", "flake8-bugbear", "flake8-comprehensions", "mypy", "types-PyYAML"]
+lint = [
+  "flake8",
+  "flake8-bugbear",
+  "flake8-comprehensions",
+  "mypy",
+  "types-PyYAML",
+]
 
 [[tool.mypy.overrides]]
 module = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -73,7 +73,6 @@ sphinx-inline-tabs = { version = "*", python = "^3.7" }
 sphinxext-opengraph = "*"
 sphinx-copybutton = "*"
 sphinxext-rediraffe = "*"
-sphinx-autoissues = "*"
 myst_parser = "*"
 docutils = "~0.18.0"
 
@@ -112,7 +111,6 @@ docs = [
   "sphinxext-opengraph",
   "sphinx-inline-tabs",
   "sphinxext-rediraffe",
-  "sphinx-autoissues",
   "myst_parser",
   "furo",
   "gp-libs",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,7 +64,7 @@ PyYAML = "<6,>=3.12"
 [tool.poetry.dev-dependencies]
 ### Docs ###
 sphinx = "*"
-gp-libs = "*"
+gp-libs = "0.0.1a10"
 furo = "*"
 sphinx-autobuild = "*"
 sphinx-autodoc-typehints = "*"


### PR DESCRIPTION
## Changes

- Render changelog in [`linkify_issues`] 
- Fix Table of contents rendering with sphinx autodoc with [`sphinx_toctree_autodoc_fix`]
- Deprecate `sphinx-autoapi`, per above fixing the table of contents issue

  This also removes the need to workaround autoapi bugs.
- Test doctests in our docs via [`pytest_doctest_docutils`] (built on [`doctest_docutils`])

[`linkify_issues`]: https://gp-libs.git-pull.com/linkify_issues/
[`sphinx_toctree_autodoc_fix`]: https://gp-libs.git-pull.com/sphinx_toctree_autodoc_fix/
[`pytest_doctest_docutils`]: https://gp-libs.git-pull.com/doctest/pytest.html
[`doctest_docutils`]: https://gp-libs.git-pull.com/doctest


## [Sphinx-click](https://github.com/click-contrib/sphinx-click) issue

https://github.com/git-pull/gp-libs/issues/11

Fixed via v0.0.1a10