### PR TITLE
docs: fix typos

### DIFF
--- a/MIGRATION
+++ b/MIGRATION
@@ -12,7 +12,7 @@ well.
 
    API changes can be painful.
 
-   If we can do something to draw the sting, we'll do it. We're taking a balanced approach. That's why these notes are here!
+   If we can do something to draw the string, we'll do it. We're taking a balanced approach. That's why these notes are here!
 
    (Please pin the package. 🙏)
 

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -13,7 +13,7 @@ $ pip install --user cihai-cli
 ### Developmental releases
 
 New versions of cihai CLI are published to PyPI as alpha, beta, or release candidates. In their
-versions you will see notfication like `a1`, `b1`, and `rc1`, respectively. `1.10.0b4` would mean
+versions you will see notification like `a1`, `b1`, and `rc1`, respectively. `1.10.0b4` would mean
 the 4th beta release of `1.10.0` before general availability.
 
 - [pip]\:


### PR DESCRIPTION
Found via `codespell -S poetry.lock`